### PR TITLE
Fixed the case where some urls and handles could be an empty string

### DIFF
--- a/apps/backend/bruno/extra-curriculo/project/get_project.bru
+++ b/apps/backend/bruno/extra-curriculo/project/get_project.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{api_url}}/projects/49a43778-6191-4e7e-8b0b-7c7fd0174899
+  url: {{api_url}}/projects/0776a8f5-2f2d-4ded-b034-6ba6c009ea05
   body: none
   auth: none
 }

--- a/apps/backend/src/domain/project/project_facebook.rs
+++ b/apps/backend/src/domain/project/project_facebook.rs
@@ -6,13 +6,13 @@ pub struct ProjectFacebook(String);
 impl ProjectFacebook {
     /// Attempts to create a `ProjectFacebook` from a given string.
     ///
-    /// If the input is an empty string, it returns an error.
     /// If the input is a non-empty string, it validates it as a URL and checks if the domain is facebook.com.
+    /// If the URL is empty, it returns `Ok` with the `ProjectFacebook`. Because it is not mandatory.
     /// Returns `Ok` with the `ProjectFacebook` if the URL is valid and belongs to Facebook.
     /// Returns `Err` with validation errors if the URL is not valid or does not belong to Facebook.
     pub fn parse(s: String) -> Result<ProjectFacebook, String> {
         if s.is_empty() {
-            Err("URL cannot be empty.".to_string())
+            return Ok(ProjectFacebook(s));
         } else if validate_url(&s) {
             let url = url::Url::parse(&s).map_err(|_| format!("{} is not a valid URL", s))?;
             let domain = url.domain().unwrap_or("");
@@ -46,9 +46,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_url_is_rejected() {
+    fn empty_url_is_accepted() {
         let result = ProjectFacebook::parse("".to_string());
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/apps/backend/src/domain/project/project_instagram.rs
+++ b/apps/backend/src/domain/project/project_instagram.rs
@@ -8,11 +8,16 @@ impl ProjectInstagram {
     /// - Must start with a letter.
     /// - Can only contain letters, numbers, periods (.), and underscores (_).
     /// - Length must be between 1 and 30 characters.
+    /// - An empty string is considered valid. Because it means the project has no Instagram handle.
     ///
     /// Returns an `Ok(ProjectInstagram)` if the input is valid, or an `Err` with a message otherwise.
     pub fn parse(s: String) -> Result<ProjectInstagram, String> {
-        if s.is_empty() || s.len() > 30 {
-            return Err("Instagram handle must be between 1 and 30 characters long.".to_string());
+        if s.is_empty() {
+            return Ok(Self(s));
+        }
+
+        if s.len() > 30 {
+            return Err("Instagram handle must be shorter than 30 chars.".to_string());
         }
 
         if !s.starts_with(char::is_alphabetic) {
@@ -68,5 +73,10 @@ mod tests {
     #[test]
     fn handle_with_invalid_chars_is_rejected() {
         assert!(ProjectInstagram::parse("invalid!handle".to_string()).is_err());
+    }
+
+    #[test]
+    fn empty_handle_is_accepted() {
+        assert!(ProjectInstagram::parse("".to_string()).is_ok());
     }
 }

--- a/apps/backend/src/domain/project/project_linkedin.rs
+++ b/apps/backend/src/domain/project/project_linkedin.rs
@@ -6,13 +6,13 @@ pub struct ProjectLinkedin(String);
 impl ProjectLinkedin {
     /// Attempts to create a `ProjectLinkedin` from a given string.
     ///
-    /// If the input is an empty string, it returns an error.
     /// If the input is a non-empty string, it validates it as a URL and checks if the domain is linkedin.com.
+    /// If the URL is empty, it returns `Ok` with the `ProjectLinkedin`. Because it is not mandatory.
     /// Returns `Ok` with the `ProjectLinkedin` if the URL is valid and belongs to LinkedIn.
     /// Returns `Err` with validation errors if the URL is not valid or does not belong to LinkedIn.
     pub fn parse(s: String) -> Result<ProjectLinkedin, String> {
         if s.is_empty() {
-            Err("URL cannot be empty.".to_string())
+            return Ok(ProjectLinkedin(s));
         } else if validate_url(&s) {
             let url = url::Url::parse(&s).map_err(|_| format!("{} is not a valid URL", s))?;
             let domain = url.domain().unwrap_or("");
@@ -46,9 +46,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_url_is_rejected() {
+    fn empty_url_is_accepted() {
         let result = ProjectLinkedin::parse("".to_string());
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/apps/backend/src/domain/project/project_twitter.rs
+++ b/apps/backend/src/domain/project/project_twitter.rs
@@ -14,7 +14,7 @@ impl ProjectTwitter {
         if s.is_empty() {
             return Ok(Self(s));
         }
-        
+
         if !s.starts_with('@') {
             Err("Twitter handle must start with '@'.".to_string())
         } else if s.len() < 2 || s.len() > 16 {
@@ -76,5 +76,4 @@ mod tests {
     fn empty_handle_is_accepted() {
         assert!(ProjectTwitter::parse("".to_string()).is_ok());
     }
-    
 }

--- a/apps/backend/src/domain/project/project_twitter.rs
+++ b/apps/backend/src/domain/project/project_twitter.rs
@@ -8,9 +8,13 @@ impl ProjectTwitter {
     /// - Must start with `@`.
     /// - Can only contain letters, numbers, and underscores.
     /// - Length must be between 2 and 15 characters, excluding the `@`.
-    ///
+    /// - If empty it is Ok. Field not mandatory.
     /// Returns `Ok(ProjectTwitter)` if the input is valid, or an `Err` with a message otherwise.
     pub fn parse(s: String) -> Result<ProjectTwitter, String> {
+        if s.is_empty() {
+            return Ok(Self(s));
+        }
+        
         if !s.starts_with('@') {
             Err("Twitter handle must start with '@'.".to_string())
         } else if s.len() < 2 || s.len() > 16 {
@@ -67,4 +71,10 @@ mod tests {
     fn valid_handle_is_accepted() {
         assert!(ProjectTwitter::parse("@valid_123".to_string()).is_ok());
     }
+
+    #[test]
+    fn empty_handle_is_accepted() {
+        assert!(ProjectTwitter::parse("".to_string()).is_ok());
+    }
+    
 }

--- a/apps/backend/src/domain/project/project_website.rs
+++ b/apps/backend/src/domain/project/project_website.rs
@@ -6,13 +6,11 @@ pub struct ProjectWebsite(String);
 impl ProjectWebsite {
     /// Attempts to create a `ProjectWebsite` from a given string.
     ///
-    /// The input string is validated as a URL. If the input is an empty string, it returns an error.
+    /// The input string is validated as a URL. If the input is an empty string, it returns Ok, because it isn't mandatory.
     /// Returns `Ok(ProjectWebsite)` if the URL is valid.
     /// Returns `Err` with validation errors if the URL is not valid.
     pub fn parse(s: String) -> Result<ProjectWebsite, String> {
-        if s.is_empty() {
-            Err("URL cannot be empty.".to_string())
-        } else if validate_url(&s) {
+        if s.is_empty() || validate_url(&s){
             Ok(ProjectWebsite(s))
         } else {
             Err(format!("{} is not a valid URL", s))
@@ -37,9 +35,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_url_is_rejected() {
+    fn empty_url_is_accepted() {
         let result = ProjectWebsite::parse("".to_string());
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/apps/backend/src/domain/project/project_website.rs
+++ b/apps/backend/src/domain/project/project_website.rs
@@ -10,7 +10,7 @@ impl ProjectWebsite {
     /// Returns `Ok(ProjectWebsite)` if the URL is valid.
     /// Returns `Err` with validation errors if the URL is not valid.
     pub fn parse(s: String) -> Result<ProjectWebsite, String> {
-        if s.is_empty() || validate_url(&s){
+        if s.is_empty() || validate_url(&s) {
             Ok(ProjectWebsite(s))
         } else {
             Err(format!("{} is not a valid URL", s))


### PR DESCRIPTION
Since not every project has Instagram, Twitter, a website, or facebook, we need to accept the fields as empty.